### PR TITLE
Add `applications` entry to app definition

### DIFF
--- a/src/dirwatch.app.src
+++ b/src/dirwatch.app.src
@@ -1,5 +1,6 @@
 {application, dirwatch,
  [{description, "Watch for activity in a directory"},
+  {applications, []},
   {vsn, git}
  ]
 }.


### PR DESCRIPTION
relx can't create a release of an application that depends on dirwatch because it can't find the `applications` key.